### PR TITLE
Export the `Ignore` class interface for TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-interface Ignore {
+export interface Ignore {
   /**
    * Adds a rule rules to the current manager.
    * @param  {string | Ignore} pattern
@@ -38,4 +38,4 @@ interface Ignore {
  */
 declare function ignore(): Ignore
 
-export = ignore 
+export = ignore


### PR DESCRIPTION
Fixes this compile error when attempting to return a `Ignore` instance:

```
TS4023: Exported variable 'createIgnoreList' has or is using name 'Ignore'
from external module "~/Code/zeit/now-cli/node_modules/@zeit/dockerignore/index"
but cannot be named.
```