### PR TITLE
Fix TypeScript Declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,4 +38,4 @@ export interface Ignore {
  */
 declare function ignore(): Ignore
 
-export = ignore
+export default ignore


### PR DESCRIPTION
This is pulling the upstream change from https://github.com/kaelzhang/node-ignore/blob/master/index.d.ts

It will also make the type match the canonical [node-ignore](https://github.com/kaelzhang/node-ignore/blob/master/index.d.ts).